### PR TITLE
Add event messages for game log actions

### DIFF
--- a/src/main/kotlin/at/aau/monopoly/klagenfurt/websocket/broker/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/monopoly/klagenfurt/websocket/broker/WebSocketBrokerController.kt
@@ -1651,7 +1651,7 @@ class WebSocketBrokerController(
         }
 
         // Process payment based on source
-         when (pending.source) {
+         val paymentResult = when (pending.source) {
              PaymentSource.RENT -> {
                  // Rent: money goes to the creditor player
                  val creditorId = pending.creditorPlayerId
@@ -1670,6 +1670,7 @@ class WebSocketBrokerController(
                  }
                  player.money -= pending.amount
                  creditor.money += pending.amount
+                 GameEvent.RENT_PAID to "${player.name} paid ${pending.amount}M to ${creditor.name}."
              }
              PaymentSource.TAX -> {
                  // Tax: money goes to Free Parking pot
@@ -1679,6 +1680,7 @@ class WebSocketBrokerController(
                  }
                  player.money -= pending.amount
                  gameState.freeParkingMoney += pending.amount
+                 GameEvent.TAX_PAID to "${player.name} paid ${pending.amount}M tax."
              }
              else -> {
                  sendGameError(action, gameState, "Unsupported payment source: ${pending.source}")
@@ -1694,19 +1696,9 @@ class WebSocketBrokerController(
              "/topic/game/${action.gameId}",
              GameEvent(
                  gameId = action.gameId,
-                 event = when (pending.source) {
-                     PaymentSource.TAX -> GameEvent.TAX_PAID
-                     else -> GameEvent.RENT_PAID
-                 },
+                 event = paymentResult.first,
                  gameState = gameState,
-                 message = when (pending.source) {
-                     PaymentSource.TAX -> "${player.name} paid ${pending.amount}M tax."
-                     PaymentSource.RENT -> {
-                         val creditorName = gameState.players.find { it.id == pending.creditorPlayerId }?.name ?: "the bank"
-                         "${player.name} paid ${pending.amount}M to ${creditorName}."
-                     }
-                     else -> "${player.name} paid ${pending.amount}M."
-                 }
+                 message = paymentResult.second
              )
          )
     }

--- a/src/main/kotlin/at/aau/monopoly/klagenfurt/websocket/broker/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/monopoly/klagenfurt/websocket/broker/WebSocketBrokerController.kt
@@ -1467,7 +1467,12 @@ class WebSocketBrokerController(
             )
             messagingTemplate.convertAndSend(
                 "/topic/game/${action.gameId}",
-                GameEvent(gameId = action.gameId, event = GameEvent.RENT_DUE, gameState = gameState)
+                GameEvent(
+                    gameId = action.gameId,
+                    event = GameEvent.RENT_DUE,
+                    gameState = gameState,
+                    message = "${player.name} owes ${rent}M rent to ${owner.name} (${landedField.name})."
+                )
             )
         }
     }
@@ -1479,11 +1484,17 @@ class WebSocketBrokerController(
         landedField: Field
     ) {
         if (landedField is FreeParkingField && gameState.freeParkingMoney > 0) {
-            player.money += gameState.freeParkingMoney
+            val collectedAmount = gameState.freeParkingMoney
+            player.money += collectedAmount
             gameState.freeParkingMoney = 0
             messagingTemplate.convertAndSend(
                 "/topic/game/${action.gameId}",
-                GameEvent(gameId = action.gameId, event = GameEvent.FREE_PARKING_COLLECTED, gameState = gameState)
+                GameEvent(
+                    gameId = action.gameId,
+                    event = GameEvent.FREE_PARKING_COLLECTED,
+                    gameState = gameState,
+                    message = "${player.name} collected ${collectedAmount}M from Free Parking!"
+                )
             )
         }
     }
@@ -1687,7 +1698,16 @@ class WebSocketBrokerController(
                      PaymentSource.TAX -> GameEvent.TAX_PAID
                      else -> GameEvent.RENT_PAID
                  },
-                 gameState = gameState)
+                 gameState = gameState,
+                 message = when (pending.source) {
+                     PaymentSource.TAX -> "${player.name} paid ${pending.amount}M tax."
+                     PaymentSource.RENT -> {
+                         val creditorName = gameState.players.find { it.id == pending.creditorPlayerId }?.name ?: "the bank"
+                         "${player.name} paid ${pending.amount}M to ${creditorName}."
+                     }
+                     else -> "${player.name} paid ${pending.amount}M."
+                 }
+             )
          )
     }
 
@@ -1723,7 +1743,12 @@ class WebSocketBrokerController(
             recomputeCanPayAfterAssets(gameState)
             messagingTemplate.convertAndSend(
                 "/topic/game/${action.gameId}",
-                GameEvent(gameId = action.gameId, event = GameEvent.PROPERTY_MORTGAGED, gameState = gameState)
+                GameEvent(
+                    gameId = action.gameId,
+                    event = GameEvent.PROPERTY_MORTGAGED,
+                    gameState = gameState,
+                    message = "${player.name} mortgaged ${field.name}."
+                )
             )
         } else if (hasBuildings) {
             sendGameError(action, gameState, "Sell all houses/hotels before mortgaging.")
@@ -1760,7 +1785,12 @@ class WebSocketBrokerController(
                 PaymentService.unmortgageProperty(player, field)
                 messagingTemplate.convertAndSend(
                     "/topic/game/${action.gameId}",
-                    GameEvent(gameId = action.gameId, event = GameEvent.PROPERTY_UNMORTGAGED, gameState = gameState)
+                    GameEvent(
+                        gameId = action.gameId,
+                        event = GameEvent.PROPERTY_UNMORTGAGED,
+                        gameState = gameState,
+                        message = "${player.name} unmortgaged ${field.name}."
+                    )
                 )
             } else {
                 sendGameError(action, gameState, "Not enough money to unmortgage. Need ${unmortgageCost}M.")
@@ -1877,7 +1907,12 @@ class WebSocketBrokerController(
 
         messagingTemplate.convertAndSend(
             "/topic/game/${action.gameId}",
-            GameEvent(gameId = action.gameId, event = GameEvent.BANKRUPTCY_DECLARED, gameState = gameState)
+            GameEvent(
+                gameId = action.gameId,
+                event = GameEvent.BANKRUPTCY_DECLARED,
+                gameState = gameState,
+                message = "${player.name} went bankrupt (debt: ${totalDebt}M, assets: ${totalAssetValue}M)."
+            )
         )
     }
 

--- a/src/test/kotlin/at/aau/monopoly/klagenfurt/websocket/broker/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/monopoly/klagenfurt/websocket/broker/WebSocketBrokerControllerTest.kt
@@ -5565,6 +5565,11 @@ class WebSocketBrokerControllerTest {
         assertEquals(PaymentSource.TAX, gameState.pendingPayment!!.source)
         assertEquals(200, gameState.pendingPayment!!.amount)
         assertTrue(events.any { it.event == GameEvent.TAX_DUE })
+        val taxDueEvent = events.find { it.event == GameEvent.TAX_DUE }!!
+        assertNotNull(taxDueEvent.message)
+        assertTrue(taxDueEvent.message!!.contains("Alice"))
+        assertTrue(taxDueEvent.message!!.contains("200"))
+        assertTrue(taxDueEvent.message!!.contains("tax"))
     }
 
     @Test

--- a/src/test/kotlin/at/aau/monopoly/klagenfurt/websocket/broker/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/monopoly/klagenfurt/websocket/broker/WebSocketBrokerControllerTest.kt
@@ -2746,6 +2746,10 @@ class WebSocketBrokerControllerTest {
 
         val event = captureLastMessages(messagingTemplate, 1).single().second as GameEvent
         assertEquals(GameEvent.RENT_PAID, event.event)
+        assertNotNull(event.message)
+        assertTrue(event.message!!.contains("Alice"))
+        assertTrue(event.message!!.contains("100M"))
+        assertTrue(event.message!!.contains("Bob"))
         assertEquals(400, gameState.players[0].money)
         assertEquals(600, gameState.players[1].money)
         assertNull(gameState.pendingPayment)
@@ -2936,6 +2940,11 @@ class WebSocketBrokerControllerTest {
 
         val event = captureLastMessages(messagingTemplate, 1).single().second as GameEvent
         assertEquals(GameEvent.BANKRUPTCY_DECLARED, event.event)
+        assertNotNull(event.message)
+        assertTrue(event.message!!.contains("Alice"))
+        assertTrue(event.message!!.contains("bankrupt"))
+        assertTrue(event.message!!.contains("debt"))
+        assertTrue(event.message!!.contains("assets"))
         assertEquals(0, gameState.players[0].money)
         assertTrue(gameState.players[0].eliminated)
         assertEquals("host-2", prop1.ownerId)
@@ -3043,6 +3052,9 @@ class WebSocketBrokerControllerTest {
 
         val event = captureLastMessages(messagingTemplate, 1).single().second as GameEvent
         assertEquals(GameEvent.PROPERTY_MORTGAGED, event.event)
+        assertNotNull(event.message)
+        assertTrue(event.message!!.contains("Alice"))
+        assertTrue(event.message!!.contains("mortgaged"))
         assertTrue(prop1.isMortgaged)
         assertEquals(500 + 60 / 2, gameState.players[0].money)
     }
@@ -3070,6 +3082,9 @@ class WebSocketBrokerControllerTest {
 
         val event = captureLastMessages(messagingTemplate, 1).single().second as GameEvent
         assertEquals(GameEvent.PROPERTY_UNMORTGAGED, event.event)
+        assertNotNull(event.message)
+        assertTrue(event.message!!.contains("Alice"))
+        assertTrue(event.message!!.contains("unmortgaged"))
         assertFalse(prop1.isMortgaged)
         assertEquals(500 - 33, gameState.players[0].money)
     }
@@ -4011,6 +4026,11 @@ class WebSocketBrokerControllerTest {
         val events = captureMessages(messagingTemplate, 2)
         val rentEvent = events.find { (it.second as? GameEvent)?.event == GameEvent.RENT_DUE }
         assertNotNull(rentEvent, "Expected RENT_DUE event when landing on owned railroad")
+        val rentEventPayload = rentEvent!!.second as GameEvent
+        assertNotNull(rentEventPayload.message)
+        assertTrue(rentEventPayload.message!!.contains("Bob"))
+        assertTrue(rentEventPayload.message!!.contains("Alice"))
+        assertTrue(rentEventPayload.message!!.contains("rent"))
         assertEquals(GamePhase.PAYING_RENT, gameState.phase)
         assertNotNull(gameState.pendingPayment)
         assertEquals(25, gameState.pendingPayment!!.amount)
@@ -4040,6 +4060,11 @@ class WebSocketBrokerControllerTest {
         val events = captureMessages(messagingTemplate, 2)
         val rentEvent = events.find { (it.second as? GameEvent)?.event == GameEvent.RENT_DUE }
         assertNotNull(rentEvent, "Expected RENT_DUE event when landing on owned utility")
+        val rentEventPayload = rentEvent!!.second as GameEvent
+        assertNotNull(rentEventPayload.message)
+        assertTrue(rentEventPayload.message!!.contains("Bob"))
+        assertTrue(rentEventPayload.message!!.contains("Alice"))
+        assertTrue(rentEventPayload.message!!.contains("rent"))
         assertEquals(GamePhase.PAYING_RENT, gameState.phase)
         assertNotNull(gameState.pendingPayment)
     }
@@ -4920,6 +4945,11 @@ class WebSocketBrokerControllerTest {
         assertEquals(1800, player.money)
         assertEquals(0, gameState.freeParkingMoney)
         assertTrue(events.any { it.event == GameEvent.FREE_PARKING_COLLECTED })
+        val fpEvent = events.find { it.event == GameEvent.FREE_PARKING_COLLECTED }!!
+        assertNotNull(fpEvent.message)
+        assertTrue(fpEvent.message!!.contains("Alice"))
+        assertTrue(fpEvent.message!!.contains("300M"))
+        assertTrue(fpEvent.message!!.contains("Free Parking"))
     }
     @Test
     fun `PAY_TAX should move money to Free Parking and emit TAX_PAID`() {
@@ -4955,6 +4985,10 @@ class WebSocketBrokerControllerTest {
         val event = captureLastMessages(messagingTemplate, 1).single().second as GameEvent
 
         assertEquals(GameEvent.TAX_PAID, event.event)
+        assertNotNull(event.message)
+        assertTrue(event.message!!.contains("Alice"))
+        assertTrue(event.message!!.contains("100M"))
+        assertTrue(event.message!!.contains("tax"))
         assertEquals(50, player.money)
         assertEquals(100, gameState.freeParkingMoney)
         assertNull(gameState.pendingPayment)

--- a/src/test/kotlin/at/aau/monopoly/klagenfurt/websocket/broker/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/monopoly/klagenfurt/websocket/broker/WebSocketBrokerControllerTest.kt
@@ -1823,12 +1823,12 @@ class WebSocketBrokerControllerTest {
             player.money = 1500
             controller.handleAction(GameAction(gameId = gameState.gameId, playerId = "host-1", action = "ROLL_DICE"))
             val payCaptor = ArgumentCaptor.forClass(Any::class.java)
-            Mockito.verify(messagingTemplate, Mockito.times(1))
+            Mockito.verify(messagingTemplate, Mockito.atLeastOnce())
                 .convertAndSend(Mockito.any(String::class.java), payCaptor.capture())
-            val event = payCaptor.value as GameEvent
+            val events = payCaptor.allValues.filterIsInstance<GameEvent>()
             if (!gameState.lastDiceRoll!!.isDouble) {
                 assertEquals(1700, player.money)
-                assertTrue(event.message!!.contains("passed Go"))
+                assertTrue(events.any { it.message?.contains("passed Go") == true })
                 break
             }
             attempts++


### PR DESCRIPTION
## Summary
- add readable messages to rent, tax, free parking, mortgage, unmortgage, and bankruptcy events
- include player names, amounts, and field context where relevant
- extend controller tests to verify emitted event messages

## Testing
- `./gradlew test --tests at.aau.monopoly.klagenfurt.websocket.broker.WebSocketBrokerControllerTest`
Ref AAU-SE2-Monopoly/aau-se2-frontend#131